### PR TITLE
Tech centre trainee acceptance

### DIFF
--- a/src/main/java/com/sparta/spartaSimulator/controller/CentreManager.java
+++ b/src/main/java/com/sparta/spartaSimulator/controller/CentreManager.java
@@ -32,7 +32,7 @@ public class CentreManager {
     public static int randomGeneration()
     {
         int count = 0;
-        int range = 0;
+        int range;
         for(Centres centre: openCentres)
         {
             if(centre.getClass().getSimpleName().equals("BootCamp"))

--- a/src/main/java/com/sparta/spartaSimulator/controller/Centres.java
+++ b/src/main/java/com/sparta/spartaSimulator/controller/Centres.java
@@ -23,4 +23,8 @@ public interface Centres {
     public int getMaxCapacity();
 
     public HashSet<Trainee> getTrainees();
+
+    //Added to let the factory created centres access this in the TraineeCentre abstract class in their own
+    //concrete classes
+    public TraineeCentre.CentreSpecialism getCentreSpecialism();
 }

--- a/src/main/java/com/sparta/spartaSimulator/controller/TraineeManager.java
+++ b/src/main/java/com/sparta/spartaSimulator/controller/TraineeManager.java
@@ -10,7 +10,9 @@ public class TraineeManager {
     private static final int MIN_TRAINEES = 20;
     private static final int MAX_TRAINEES = 30;
     private static final int RANGE = MAX_TRAINEES-MIN_TRAINEES+1;
-    private static ArrayList<Trainee> unplacedTrainees = new ArrayList<>();
+
+    //Made this public for testing purposes in TechCentreTests || change back when happy
+    public static ArrayList<Trainee> unplacedTrainees = new ArrayList<>();
 
     public static Trainee[] createTrainees(int randomNumber){
         //done as array as size is passed through, but can be changed to what is used in other classes

--- a/src/main/java/com/sparta/spartaSimulator/model/TechCentre.java
+++ b/src/main/java/com/sparta/spartaSimulator/model/TechCentre.java
@@ -4,12 +4,11 @@ import com.sparta.spartaSimulator.controller.Centres;
 
 public class TechCentre extends TraineeCentre implements Centres {
 
-    private Trainee.TraineeCourse centreTraineeCourse;
-
     public TechCentre() {
         setMaxCapacity(200);
         setCentreStatus(CentreStatus.NOT_FULL);
-        Trainee.setCentreTraineeCourse(centreTraineeCourse);
+        //This method now belongs only in the TraineeCentre class, needed to change from Trainee to remove reliance
+        //of this class only on the interface and TraineeCentre. Think its a SOLID principle maybe... I'm so tired.
+        setCentreSpecialism(CentreSpecialism.DATA);
     }
-
 }

--- a/src/main/java/com/sparta/spartaSimulator/model/TechCentre.java
+++ b/src/main/java/com/sparta/spartaSimulator/model/TechCentre.java
@@ -4,16 +4,12 @@ import com.sparta.spartaSimulator.controller.Centres;
 
 public class TechCentre extends TraineeCentre implements Centres {
 
-    /*
-        private TrainingType;
-     */
+    private Trainee.TraineeCourse centreTraineeCourse;
 
     public TechCentre() {
         setMaxCapacity(200);
         setCentreStatus(CentreStatus.NOT_FULL);
-        /*
-            setTrainingType()
-         */
+        Trainee.setCentreTraineeCourse(centreTraineeCourse);
     }
 
 }

--- a/src/main/java/com/sparta/spartaSimulator/model/Trainee.java
+++ b/src/main/java/com/sparta/spartaSimulator/model/Trainee.java
@@ -39,6 +39,10 @@ public class Trainee {
 
     }
 
+    public static void setCentreTraineeCourse(TraineeCourse centreTraineeCourse) {
+        centreTraineeCourse = courses.get(RANDOM.nextInt(5));
+    }
+
     public TraineeCourse getTraineeCourse() {
         return traineeCourse;
     }

--- a/src/main/java/com/sparta/spartaSimulator/model/Trainee.java
+++ b/src/main/java/com/sparta/spartaSimulator/model/Trainee.java
@@ -36,11 +36,12 @@ public class Trainee {
     public Trainee() {
         this.traineeStatus = TraineeStatus.UNPLACED;
         this.traineeCourse = courses.get(RANDOM.nextInt(5));
-
     }
 
-    public static void setCentreTraineeCourse(TraineeCourse centreTraineeCourse) {
-        centreTraineeCourse = courses.get(RANDOM.nextInt(5));
+    //testing purposes so I could set the course type for Trainee when testing in TechCentreTests
+    public Trainee(TraineeCourse course) {
+        this.traineeStatus = TraineeStatus.UNPLACED;
+        this.traineeCourse = course;
     }
 
     public TraineeCourse getTraineeCourse() {

--- a/src/main/java/com/sparta/spartaSimulator/model/TraineeCentre.java
+++ b/src/main/java/com/sparta/spartaSimulator/model/TraineeCentre.java
@@ -2,19 +2,39 @@ package com.sparta.spartaSimulator.model;
 
 import com.sparta.spartaSimulator.controller.CentreManager;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Random;
 
 public abstract class TraineeCentre {
 
     private HashSet<Trainee> allTrainees = new HashSet<>();
     private int MAX_CAPACITY;
     private CentreStatus centreStatus;
+    private CentreSpecialism centreSpecialism;
+    private static final Random RANDOM = new Random();
 
     public enum CentreStatus{
         FULL,
         NEARLY_FULL,
         NOT_FULL
     }
+
+    public enum CentreSpecialism {
+        JAVA,
+        CSHARP,
+        DATA,
+        DEVOPS,
+        BUSINESS
+    }
+
+    private static final ArrayList<CentreSpecialism> courses = new ArrayList<>(Arrays.asList(
+            CentreSpecialism.JAVA,
+            CentreSpecialism.CSHARP,
+            CentreSpecialism.DATA,
+            CentreSpecialism.DEVOPS,
+            CentreSpecialism.BUSINESS));
 
     public TraineeCentre() {
         this.centreStatus = CentreStatus.NOT_FULL;
@@ -46,8 +66,20 @@ public abstract class TraineeCentre {
         }
     }
 
+    //Changes to this method to check specialism against centres
     public void addTrainee(Trainee trainee){
-        allTrainees.add(trainee);
+        String specialism = "";
+        try
+        {
+            specialism = getCentreSpecialism().toString();
+        } catch (NullPointerException ex)
+        {
+            allTrainees.add(trainee);
+        }
+        if(trainee.getTraineeCourse().toString().equals(specialism))
+        {
+            allTrainees.add(trainee);
+        }
         checkCentreStatus();
     }
 
@@ -70,6 +102,20 @@ public abstract class TraineeCentre {
 
     public HashSet<Trainee> getTrainees(){
         return allTrainees;
+    }
+
+    public CentreSpecialism getCentreSpecialism() {
+        return centreSpecialism;
+    }
+
+    //This is going to be used in actual program
+    public void setCentreSpecialism() {
+        this.centreSpecialism = courses.get(RANDOM.nextInt(5));
+    }
+
+    //This is the test setter method so I could test against a specific specialism || Delete when happy with results
+    public void setCentreSpecialism(CentreSpecialism centreSpecialism) {
+        this.centreSpecialism = centreSpecialism;
     }
 
 }

--- a/src/main/java/com/sparta/spartaSimulator/model/WaitingList.java
+++ b/src/main/java/com/sparta/spartaSimulator/model/WaitingList.java
@@ -7,7 +7,8 @@ import java.util.HashSet;
 
 public class WaitingList {
 
-    private static ArrayList<Trainee> waitingList = new ArrayList<>();
+    //made this public for tests in TechCentreTestsClass
+    public static ArrayList<Trainee> waitingList = new ArrayList<>();
 
 
     public static ArrayList<Trainee> getWaitingList() {

--- a/src/main/java/com/sparta/spartaSimulator/model/WaitingList.java
+++ b/src/main/java/com/sparta/spartaSimulator/model/WaitingList.java
@@ -8,7 +8,7 @@ import java.util.HashSet;
 public class WaitingList {
 
     //made this public for tests in TechCentreTestsClass
-    public static ArrayList<Trainee> waitingList = new ArrayList<>();
+    private static ArrayList<Trainee> waitingList = new ArrayList<>();
 
 
     public static ArrayList<Trainee> getWaitingList() {

--- a/src/test/java/com/sparta/spartaSimulator/TechCentreTests.java
+++ b/src/test/java/com/sparta/spartaSimulator/TechCentreTests.java
@@ -1,0 +1,45 @@
+package com.sparta.spartaSimulator;
+
+import com.sparta.spartaSimulator.controller.CentreManager;
+import com.sparta.spartaSimulator.controller.Centres;
+import com.sparta.spartaSimulator.controller.Factory;
+import com.sparta.spartaSimulator.controller.TraineeManager;
+import com.sparta.spartaSimulator.model.Trainee;
+import com.sparta.spartaSimulator.model.WaitingList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class TechCentreTests {
+
+    @Test
+    public void creationTypeCheck() {
+        Centres centres = Factory.centreFactory(2);
+        Assertions.assertNotNull(centres);
+        Assertions.assertNotNull(centres.getCentreSpecialism());
+    }
+
+    @Test
+    public void TechCentreOnlyAcceptsType()
+    {
+        //Due to randomisation of centres taking in Trainees, this sometimes fails, but it does work i think
+        Centres centres = Factory.centreFactory(2);
+        CentreManager.addCentreToOpenCentres(centres);
+        Trainee trainee = new Trainee(Trainee.TraineeCourse.JAVA);
+        Trainee trainee1 = new Trainee(Trainee.TraineeCourse.DATA);
+        Trainee trainee2 = new Trainee(Trainee.TraineeCourse.DATA);
+        Trainee trainee3 = new Trainee(Trainee.TraineeCourse.BUSINESS);
+        TraineeManager.unplacedTrainees.add(trainee);
+        TraineeManager.unplacedTrainees.add(trainee1);
+        TraineeManager.unplacedTrainees.add(trainee2);
+        TraineeManager.unplacedTrainees.add(trainee3);
+        CentreManager.addTrainees(CentreManager.openCentres);
+        Assertions.assertEquals(2, centres.getCurrentCapacity());
+        for(Trainee train: WaitingList.waitingList)
+        {
+            System.out.println(train.getTraineeCourse().toString());
+        }
+    }
+}

--- a/src/test/java/com/sparta/spartaSimulator/TechCentreTests.java
+++ b/src/test/java/com/sparta/spartaSimulator/TechCentreTests.java
@@ -37,7 +37,7 @@ public class TechCentreTests {
         TraineeManager.unplacedTrainees.add(trainee3);
         CentreManager.addTrainees(CentreManager.openCentres);
         Assertions.assertEquals(2, centres.getCurrentCapacity());
-        for(Trainee train: WaitingList.waitingList)
+        for(Trainee train: WaitingList.getWaitingList())
         {
             System.out.println(train.getTraineeCourse().toString());
         }


### PR DESCRIPTION
Here we go:
- Reliance of Trainee Course types removed and given to Trainee Centre (Only did this because I thought it made sense in terms of class responsibility, if not then I can just change it back no worries)
- Enums added to Trainee Centre for reasons above
- The original set method has been deleted from Trainee for the centre course enum setting as this is now done in Trainee Centre
- New method added to Trainee centre to get and set value of Tech Centre specialism
- A test version of the set Centre Specialism is currently being used so I could define what the centres specialism is, but the one above is the random version we will use in the actual program.
- The above getter has been added to Centre interface so it can be used across factory classes 
- Trainee manager unplaced Trainees array changed to public purely so I could use it in tests, so feel free to change back
- Trainee Centre also has changes to add Trainee to check if the course type matches the tech centre type before adding, this does check for a null value first, ensuring that if the centre has no specialism then we add the trainee anyway. The difference is that if the tech centre we are adding to is not of the same type then the trainee is not added, but this does not dictate where that trainee goes after being rejected.
- I think that's all, sorry for rambling. Any questions then hit me up